### PR TITLE
Add group update

### DIFF
--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -14,6 +14,12 @@ class Api::GroupsController < ApplicationController
     render json: group
   end
 
+  def update
+    group = Group.find(params[:id])
+    group.update(group_params)
+    render json: group
+  end
+
   private
 
   def group_params

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -3,4 +3,9 @@ class Api::GroupsController < ApplicationController
     @groups = Group.all
     render json: @groups
   end
+
+  def show
+    @group = (params[:id] == 'undefined') ? Group.first : Group.find(params[:id])
+    render json: @group
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   root 'home#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
-    resources :groups, only: [:index, :create, :show]
+    resources :groups, only: [:index, :create, :show, :update]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   root 'home#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
-    resources :groups, only: :index
+    resources :groups, only: [:index, :show]
   end
 end

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div class='Wrapper'>
-    <Sidebar :modal='modal' />
-    <ChatMain :modal='modal' />
+    <Sidebar />
+    <ChatMain />
   </div>
 </template>
 
@@ -12,7 +12,6 @@
   export default {
     data: ()=>{
       return {
-        modal: false
       }
     },
     components: {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div class='Wrapper'>
-    <Sidebar />
-    <ChatMain />
+    <Sidebar :modal='modal' />
+    <ChatMain :modal='modal' />
   </div>
 </template>
 
@@ -11,12 +11,14 @@
 
   export default {
     data: ()=>{
-      return {}
+      return {
+        modal: false
+      }
     },
     components: {
       Sidebar,
       ChatMain
-    }
+    },
   }
 </script>
 

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -3,9 +3,7 @@
     <header class='group-header'>
       <div class="current-group">
         <p class='current-group-name'>{{ this.currentGroup.name }}</p>
-        <!-- $emitでAppコンポーネントのom→openEditModalが発火する -->
         <p @click="openEditModal" class='edit-group-btn'>編集</p>
-        <!-- $emitでAppコンポーネントのcm→closeEditModalが発火する -->
         <Modal ref='modalEdit' @close="closeEditModal" v-if='modalEdit'>
           <!-- Modalのslotに差し込む -->
           <button @click="updateGroup">編集</button>

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -3,7 +3,18 @@
     <header class='group-header'>
       <div class="current-group">
         <p class='current-group-name'>{{ this.currentGroup.name }}</p>
-        <p class='edit-group-btn'>編集</p>
+        <p @click="openModal" class='edit-group-btn'>編集</p>
+        <Modal ref='modal' @close='closeModal' v-if='modal'>
+          <!-- Modalのslotに差し込む -->
+          <label class='group-form-label'>新しいグループ名</label>
+          <div><input v-model="groupName"></div>
+          <!-- slot ここまで -->
+          <!-- Modalのslot name=footerに差し込む -->
+          <template slot="footer">
+            <button @click="updateGroup">編集</button>
+          </template>
+          <!-- slot name=footer ここまで -->
+        </Modal>
       </div>
       <p class='remove-group-btn'>チャットグループを削除する</p>
     </header>
@@ -36,12 +47,15 @@
 
 <script>
   import axios from 'axios'
-  import Sidebar from './Sidebar.vue'
+  import Modal from './Modal.vue'
 
   export default {
+    components: { Modal },
+    props: ['modal'],
     data() {
       return {
         currentGroup: '',
+        groupName: '',
       }
     },
     mounted() {
@@ -53,7 +67,17 @@
         axios.get(`/api/groups/${id}`).then((res) => {
           this.currentGroup = res.data
         })
-      }
+      },
+      updateGroup() {
+        console.log(2)
+      },
+      openModal() {
+        this.groupName = this.currentGroup.name
+        this.modal = true
+      },
+      closeModal() {
+        this.modal = false
+      },
     }
   }
 </script>
@@ -85,6 +109,10 @@
     margin-left: 1rem;
     padding-top: 1rem;
     color: #aaa;
+    cursor: pointer;
+  }
+  .group-form-label {
+    color: #222;
   }
   .remove-group-btn {
     margin-right: 1rem;

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -2,7 +2,7 @@
   <article class='chat-main'>
     <header class='group-header'>
       <div class="current-group">
-        <p class='current-group-name'>CurrentGroup</p>
+        <p class='current-group-name'>{{ this.currentGroup.name }}</p>
         <p class='edit-group-btn'>編集</p>
       </div>
       <p class='remove-group-btn'>チャットグループを削除する</p>
@@ -35,6 +35,27 @@
 </template>
 
 <script>
+  import axios from 'axios'
+  import Sidebar from './Sidebar.vue'
+
+  export default {
+    data() {
+      return {
+        currentGroup: '',
+      }
+    },
+    mounted() {
+      this.fetchCurrentGroup()
+    },
+    methods: {
+      fetchCurrentGroup(id) {
+        // /api/groups/:idを叩く
+        axios.get(`/api/groups/${id}`).then((res) => {
+          this.currentGroup = res.data
+        })
+      }
+    }
+  }
 </script>
 
 <style scoped>

--- a/frontend/src/components/Modal.vue
+++ b/frontend/src/components/Modal.vue
@@ -25,10 +25,14 @@
     },
     methods: {
       createGroup() {
-        // csrfトークン
-        const token = document.querySelector('meta[name=csrf-token]').getAttribute('content')
         // モーダルで入力された値
         const groupName = this.$parent.groupName
+        if (groupName === '') {
+          alert('グループ名を入力して下さい')
+          return
+        }
+        // csrfトークン
+        const token = document.querySelector('meta[name=csrf-token]').getAttribute('content')
         // ActionCable用チャンネル
         const groupChannel = this.$parent.groupChannel
         // post /api/groups を叩く

--- a/frontend/src/components/Modal.vue
+++ b/frontend/src/components/Modal.vue
@@ -1,6 +1,7 @@
 <template>
   <transition name="modal" appear>
     <!-- イベントにselfをつけると他の要素に伝播しなくなる -->
+    <!-- $emitで親コンポーネントのcloseイベントを発火する -->
     <div class="modal-overlay" @click.self="$emit('close')">
       <div class="modal-window">
         <div class="modal-content">

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -30,9 +30,9 @@
 
   export default {
     components: { Modal },
+    props: ['modal'],
     data() {
       return {
-        modal: false, // modalの表示/非表示管理
         groupName: '',
         groupList: [],
         groupChannel: null // ActionCable用

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1,8 +1,7 @@
 <template>
   <aside class='sidebar'>
-    <!-- $emitでAppコンポーネントのom→openNewModalが発火する -->
     <span @click="openNewModal" class="material-icons new-group-btn">add_circle_outline</span>
-     <!-- $emitでAppコンポーネントのom→closeNewModalが発火する -->
+    <!-- 子コンポーネントからcloseの発火を受けたらcloseNewModalを動かす -->
     <Modal ref='modalNew' @close="closeNewModal" v-if='modalNew'>
       <!-- Modalのslotに差し込む -->
       <button @click="createGroup">送信</button>
@@ -56,7 +55,7 @@
       },
       createGroup() {
         // $refsで子コンポーネントのメソッドを使える
-        // modalNewはModalコンポーネントを呼ぶ時(6行目)にref=を使って名付けている
+        // modalNewはModalコンポーネントを呼ぶ時にref=を使って名付けている
         this.$refs.modalNew.createGroup()
       }
     }

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1,19 +1,11 @@
 <template>
   <aside class='sidebar'>
-    <!-- クリックしたらopenModalメソッドを動かす -->
-    <span @click="openModal" class="material-icons new-group-btn">add_circle_outline</span>
-    <!-- data.modalがtrueになったらModalコンポーネントが表示される -->
-    <Modal ref='modal' @close='closeModal' v-if='modal'>
-      <!-- methodはこっちに書きたいのでslotを使う -->
+    <!-- $emitでAppコンポーネントのom→openNewModalが発火する -->
+    <span @click="openNewModal" class="material-icons new-group-btn">add_circle_outline</span>
+     <!-- $emitでAppコンポーネントのom→closeNewModalが発火する -->
+    <Modal ref='modalNew' @close="closeNewModal" v-if='modalNew'>
       <!-- Modalのslotに差し込む -->
-      <label class='group-form-label'>グループ名</label>
-      <div><input v-model="groupName"></div>
-      <!-- slot ここまで -->
-      <!-- Modalのslot name=footerに差し込む -->
-      <template slot="footer">
-        <button @click="createGroup">送信</button>
-      </template>
-      <!-- slot name=footer ここまで -->
+      <button @click="createGroup">送信</button>
     </Modal>
     <section class='group-container'>
       <div class='group'  v-for="group in groupList" :key="group.id">
@@ -26,14 +18,14 @@
 
 <script>
   import axios from 'axios'
+  import {getGroups} from '../modules/api'
   import Modal from './Modal.vue'
 
   export default {
     components: { Modal },
-    props: ['modal'],
     data() {
       return {
-        groupName: '',
+        modalNew: false,
         groupList: [],
         groupChannel: null // ActionCable用
       }
@@ -41,8 +33,9 @@
     created() {
       this.groupChannel = this.$cable.subscriptions.create( "GroupChannel",{
         received: (data) => {
-          // ActionCableで配信されてきたものがdataに入る
-          this.groupList.push(data)
+          // ActionCableから配信があったらサイドバーを更新する
+          this.groupList = []
+          this.fetchGroups()
         },
       })
     },
@@ -51,26 +44,20 @@
       this.fetchGroups()
     },
     methods: {
+      openNewModal() {
+        this.modalNew = true
+      },
+      closeNewModal() {
+        this.modalNew = false
+      },
       fetchGroups() {
-        // /api/groupsを叩いてレスポンスをresで受け取る
-        axios.get('/api/groups').then((res) => {
-          // res.dataにコントローラで作った@groupsのJSONが入ってる
-          for(var i = 0; i < res.data.length; i++) {
-            // this.groupsに上記jsonをforで回しながらpushしていく
-            this.groupList.push(res.data[i]);
-          }
-        }, (error) => {
-          alert(error)
-        });
-      },
-      openModal() {
-        this.modal = true
-      },
-      closeModal() {
-        this.modal = false
+        // api.jsのgetGroupsにgroupListを渡す
+        getGroups(this.groupList)
       },
       createGroup() {
-        this.$refs.modal.createGroup()
+        // $refsで子コンポーネントのメソッドを使える
+        // modalNewはModalコンポーネントを呼ぶ時(6行目)にref=を使って名付けている
+        this.$refs.modalNew.createGroup()
       }
     }
   }
@@ -91,9 +78,6 @@
     padding-bottom: 1.2rem;
     font-size: 3rem;
     cursor: pointer;
-  }
-  .group-form-label {
-    color: #222;
   }
   .group-container {
     height: calc(100% - 5.4rem);

--- a/frontend/src/modules/api.js
+++ b/frontend/src/modules/api.js
@@ -1,9 +1,45 @@
 import axios from 'axios'
 
+// グループ全件取得
+// /api/groupsを叩き、結果をgroupListに入れる
+export const getGroups = (groupList)=> {
+  axios
+    .get('/api/groups')
+      .then(
+        (res) => {
+          for(var i = 0; i < res.data.length; i++) {
+            // this.groupListに上記resをforで回しながらpushしていく
+            groupList.push(res.data[i]);
+          }
+        },
+        (error) =>{
+          alert(error)
+        }
+      )
+}
+
 // グループ作成
 export const postGroup = (token, groupName, groupChannel)=> {
   axios
     .post('/api/groups', {
+      authenticity_token: token,
+      name: groupName
+    })
+    .then((res) =>{
+      if (res.status === 200) {
+        groupChannel.perform('display', {
+          group: res.data
+        });
+      } else {
+        alert(`${res.status} ${res.statusText}`)
+      }
+    })
+}
+
+// グループ編集
+export const putGroup = (token, groupId, groupName, groupChannel)=> {
+  axios
+    .put(`/api/groups/${groupId}`, {
       authenticity_token: token,
       name: groupName
     })

--- a/spec/requests/api/groups_request_spec.rb
+++ b/spec/requests/api/groups_request_spec.rb
@@ -41,4 +41,34 @@ RSpec.describe "Api::Groups", type: :request do
       end
     end
   end
+
+  describe '#update (PUT /api/groups/:id)' do
+    let(:group) { create(:group, name: 'default_name') }
+
+    context '正常なパラメータの場合' do
+      let(:valid_params) {{ name: 'changed_name' }}
+
+      it 'グループ名が更新されること' do
+        put api_group_path(group), params: valid_params
+
+        expect(group.reload.name).to eq 'changed_name'
+      end
+
+      it '正常なレスポンスを返すこと' do
+        post api_groups_path(group), params: valid_params
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context '異常なパラメータの場合' do
+      let(:invalid_params) {{ name: nil }}
+
+      it 'グループ名が更新されないこと' do
+        put api_group_path(group), params: invalid_params
+
+        expect(group.reload.name).to eq 'default_name'
+      end
+    end
+  end
 end

--- a/spec/requests/api/groups_request_spec.rb
+++ b/spec/requests/api/groups_request_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Api::Groups", type: :request do
   describe '#index (GET /api/groups)' do
-    it '/api/groups を叩くと正常なレスポンスを返す' do
+    it 'groupsのレコード全てを返す' do
       # 事前に10件用意する
       create_list(:group, 10)
 
@@ -13,6 +13,20 @@ RSpec.describe "Api::Groups", type: :request do
       expect(response).to have_http_status(:success)
       # ちゃんと全件取得しているか
       expect(json.length).to eq(10)
+    end
+  end
+
+  describe '#show (GET /api/groups/:id)' do
+    let(:group) { create(:group) }
+
+    it '期待したgroupsのレコード1件を返す' do
+      get api_group_path(group)
+
+      json = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:success)
+      # 取得したグループが事前に作ったグループと同じか
+      expect(json['id']).to eq(group.id)
     end
   end
 


### PR DESCRIPTION
# 変更内容の説明
- api/groups#show アクションを実装し、既存のグループから1件グループを取得するようにしました
- ChatMainコンポーネントのマウント時に上記showアクションを叩き、受け取ったデータをcurrentGroupとして管理するようにしました
- api/groups#update アクションを実装し、既存のグループを更新できるようにしました
- ModalコンポーネントにupdateGroupメソッドを実装し、上記updateアクションを叩いてグループ編集ができるようにしました
  - この際、更新されたグループをActionCableで返すようにしました
- Sidebarコンポーネントでは、ActionCableから配信があればfetchGroupsを発火し直すことでグループの追加・編集時にサイドバーを更新するようにしました
- ChatMainコンポーネントでは、ActionCableから配信があったデータと現在見ているグループを照合して処理を分けました
  - idが一致する場合＝グループの編集である為、currentGroupを更新します
  - idが一致しない場合＝グループの追加である為、ChatMainコンポーネントでは何もしません

# ユーザーストーリー
- トップページにアクセスした際、最も古いグループのグループ名が表示されるようになりました
- ヘッダの編集ボタンを押すとモーダルが開き、グループ名を送信すると既存グループの名前を変更できるようになりました
- グループ名が編集されると、他のユーザーのサイドバーも非同期的に更新されるようになりました

# プルリク提出時の確認事項
下記全てにチェック（x）をつけてから提出しましょう。

## コーディングの品質向上

- [x] **1.コメント**：初心者エンジニアにも分かりやすいような、相手目線でのコメントを書いた。
- [x] **2.テスト**：ユースケースが追加/変更された場合は、それに対して変更に強いテストを書いた。

## プルリクの品質向上
- [x] **3.UIのキャプチャ**：UIに変更がある場合は、変更点が分かりやすく伝わるように、キャプチャを貼っている。
![group_update](https://user-images.githubusercontent.com/43090220/86512101-f91c0d80-be39-11ea-990d-b3b702d754fa.gif)
