### PR TITLE
[開発研修]Add groups destroy

### DIFF
--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -11,19 +11,20 @@ class Api::GroupsController < ApplicationController
 
   def create
     group = Group.create(group_params)
-    render json: group
+    render json: {group: group, action: :create}
   end
 
   def update
     group = Group.find(params[:id])
     group.update(group_params)
-    render json: group
+    render json: {group: group, action: :update}
   end
 
   def destroy
     group = Group.find(params[:id])
     group.destroy
-    render json: {id: params[:id]}
+    next_group = Group.first
+    render json: {group: next_group, action: :destroy}
   end
 
   private

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -20,6 +20,12 @@ class Api::GroupsController < ApplicationController
     render json: group
   end
 
+  def destroy
+    group = Group.find(params[:id])
+    group.destroy
+    render json: {id: params[:id]}
+  end
+
   private
 
   def group_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   root 'home#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
-    resources :groups, only: [:index, :create, :show, :update]
+    resources :groups, only: [:index, :create, :show, :update, :destroy]
   end
 end

--- a/frontend/src/modules/api.js
+++ b/frontend/src/modules/api.js
@@ -53,3 +53,24 @@ export const putGroup = (token, groupId, groupName, groupChannel)=> {
       }
     })
 }
+
+// グループ削除
+export const deleteGroup = (token, groupId, groupChannel)=> {
+  console.log(token)
+  axios
+    .delete(`/api/groups/${groupId}`, {
+      data: { // deleteでparamsを送りたい時は data: が必要
+        authenticity_token: token
+      }
+    })
+      .then((res)=> {
+        if (res.status === 200) {
+          groupChannel.perform('display', {
+            // 返り値は削除したグループのid
+            group: res.data
+          });
+        } else {
+          alert(`${res.status} ${res.statusText}`)
+        }
+      })
+}

--- a/frontend/src/modules/api.js
+++ b/frontend/src/modules/api.js
@@ -56,7 +56,6 @@ export const putGroup = (token, groupId, groupName, groupChannel)=> {
 
 // グループ削除
 export const deleteGroup = (token, groupId, groupChannel)=> {
-  console.log(token)
   axios
     .delete(`/api/groups/${groupId}`, {
       data: { // deleteでparamsを送りたい時は data: が必要
@@ -66,7 +65,7 @@ export const deleteGroup = (token, groupId, groupChannel)=> {
       .then((res)=> {
         if (res.status === 200) {
           groupChannel.perform('display', {
-            // 返り値は削除したグループのid
+            // 返り値は存在する別のグループ
             group: res.data
           });
         } else {

--- a/spec/requests/api/groups_request_spec.rb
+++ b/spec/requests/api/groups_request_spec.rb
@@ -87,16 +87,14 @@ RSpec.describe "Api::Groups", type: :request do
   end
 
   describe '#destroy (DELETE /api/groups/:id)' do
-    it 'groupsのレコードが1件減り、削除したgroupのidを返すこと' do
+    it 'groupsのレコードが1件減り、正常なレスポンスを返すこと' do
       group = create(:group)
 
       expect {
         delete api_group_path(group)
       }.to change(Group, :count).by(-1)
 
-      json = JSON.parse(response.body)
       expect(response).to have_http_status(:success)
-      expect(json['id']).to eq group.id.to_s
     end
   end
 end

--- a/spec/requests/api/groups_request_spec.rb
+++ b/spec/requests/api/groups_request_spec.rb
@@ -85,4 +85,18 @@ RSpec.describe "Api::Groups", type: :request do
       end
     end
   end
+
+  describe '#destroy (DELETE /api/groups/:id)' do
+    it 'groupsのレコードが1件減り、削除したgroupのidを返すこと' do
+      group = create(:group)
+
+      expect {
+        delete api_group_path(group)
+      }.to change(Group, :count).by(-1)
+
+      json = JSON.parse(response.body)
+      expect(response).to have_http_status(:success)
+      expect(json['id']).to eq group.id.to_s
+    end
+  end
 end


### PR DESCRIPTION
# 変更内容の説明
- api/groups#destroyを実装し、groupsテーブルからレコードを削除できるようになりました
  - 削除後は存在するグループでidの一番若いものを返すようにしました
- api.jsにdeleteGroupモジュールを実装し、上記groups#destroyを叩くようにしました
- ChatMainコンポーネントにdestroyGroupメソッドを実装し、確認ダイアログ出現後、上記deleteGroupを呼ぶようにしました
  - また、deleteGroupの実行後、ActionCableを使い配信されてきたグループを、currentGroupと入れ替えるようにしました
    - 現在はcurrentGroupが固定なのでこれで良いですが、グループを選択できるようになった際はcurrentGroupと削除されたグループが同じかどうかの検証を実装します

# ユーザーストーリー
- ヘッダに表示されているグループを削除できるようになりました
- 他のユーザーがグループを削除した際、自動でヘッダに別のグループが表示されるようになりました

# プルリク提出時の確認事項
下記全てにチェック（x）をつけてから提出しましょう。

## コーディングの品質向上

- [x] **1.コメント**：初心者エンジニアにも分かりやすいような、相手目線でのコメントを書いた。
- [x] **2.テスト**：ユースケースが追加/変更された場合は、それに対して変更に強いテストを書いた。

## プルリクの品質向上
- [x] **3.UIのキャプチャ**：UIに変更がある場合は、変更点が分かりやすく伝わるように、キャプチャを貼っている。
![group_destroy](https://user-images.githubusercontent.com/43090220/86561644-1832b080-bf9c-11ea-8052-c00d060d38eb.gif)
