### PR TITLE
[開発研修]Add group select

### DIFF
--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -24,7 +24,7 @@ class Api::GroupsController < ApplicationController
     group = Group.find(params[:id])
     group.destroy
     next_group = Group.first
-    render json: {group: next_group, action: :destroy}
+    render json: {removed_id: params[:id].to_i, group: next_group, action: :destroy}
   end
 
   private

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -2,7 +2,7 @@
   <article class='chat-main'>
     <header class='group-header'>
       <div class="current-group">
-        <p class='current-group-name'>{{ this.currentGroup.name }}</p>
+        <p class='current-group-name'>{{ sharedState.currentGroup.name }}</p>
         <p @click="openEditModal" class='edit-group-btn'>編集</p>
         <Modal ref='modalEdit' @close="closeEditModal" v-if='modalEdit'>
           <!-- Modalのslotに差し込む -->
@@ -40,6 +40,7 @@
 
 <script>
   import axios from 'axios'
+  import store from '../store'
   import {deleteGroup} from '../modules/api'
   import Modal from './Modal.vue'
 
@@ -48,7 +49,7 @@
     data() {
       return {
         modalEdit: false,
-        currentGroup: {},
+        sharedState: store.state, // store.stateまでしか読めない？currentGroupつけるとエラー
         groupChannel: null, // ActionCable用
         token: ''
       }
@@ -60,11 +61,11 @@
           // data.actionにどのアクションから来たか(create/update/destroy)を格納してある
           if (data.action === 'update') {
             // updateならdataはcurrentGroupと同じグループのはずなのでヘッダのグループ名を更新
-            this.currentGroup = data.group
+            store.setCurrentGroup(data.group)
           } else if (data.action === 'destroy') {
             // destroyなら別のグループが送られてきているので削除されたことを通知して移動
             alert('このグループは削除されたため、別のグループへ移動します')
-            this.currentGroup = data.group
+            store.setCurrentGroup(data.group)
           }
           // createの時は何もしない(Sidebarコンポーネントの更新はある)
         },
@@ -81,21 +82,21 @@
       closeEditModal() {
         this.modalEdit = false
       },
-      // api.jsに引っ越すとうまくいかない
-      // this.currentGroupに対して別メソッド内で代入するとおかしくなる？
       fetchCurrentGroup(id) {
         axios
           .get(`/api/groups/${id}`)
             .then((res) => {
-              this.currentGroup = res.data
+              // currentGroupの状態はstoreで管理している
+              // store内のデータ書き換えはstore内のメソッドに任せる
+              store.setCurrentGroup(res.data)
             })
       },
       updateGroup() {
-        this.$refs.modalEdit.updateGroup(this.currentGroup.id)
+        this.$refs.modalEdit.updateGroup(this.sharedState.currentGroup.id)
       },
       destroyGroup() {
         if (confirm('本当に削除しますか？')) {
-          deleteGroup(this.token, this.currentGroup.id, this.groupChannel)
+          deleteGroup(this.token, this.sharedState.currentGroup.id, this.groupChannel)
         }
       }
     }

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -59,11 +59,11 @@
         received: (data) => {
           // ActionCableで配信されてきたものがdataに入る
           // data.actionにどのアクションから来たか(create/update/destroy)を格納してある
-          if (data.action === 'update') {
-            // updateならdataはcurrentGroupと同じグループのはずなのでヘッダのグループ名を更新
+          if (data.action === 'update' && data.group.id === this.sharedState.currentGroup.id) {
+            // updateかつ、currentGroupへの更新ならヘッダのグループ名を更新
             store.setCurrentGroup(data.group)
-          } else if (data.action === 'destroy') {
-            // destroyなら別のグループが送られてきているので削除されたことを通知して移動
+          } else if (data.action === 'destroy' && data.removed_id === this.sharedState.currentGroup.id) {
+            // destroyかつ、currentGroupが削除されたなら別のグループが送られてきているので削除されたことを通知して移動
             alert('このグループは削除されたため、別のグループへ移動します')
             store.setCurrentGroup(data.group)
           }

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -8,7 +8,7 @@
     </Modal>
     <section class='group-container'>
       <div class='group'  v-for="group in groupList" :key="group.id">
-        <p class='group-name'>{{ group.name }}</p>
+        <p @click="selectGroup(group)" class='group-name'>{{ group.name }}</p>
         <span class='group-notice'> {{ group.id }} </span>
       </div>
     </section>
@@ -17,6 +17,7 @@
 
 <script>
   import axios from 'axios'
+  import store from '../store'
   import {getGroups} from '../modules/api'
   import Modal from './Modal.vue'
 
@@ -57,6 +58,9 @@
         // $refsで子コンポーネントのメソッドを使える
         // modalNewはModalコンポーネントを呼ぶ時にref=を使って名付けている
         this.$refs.modalNew.createGroup()
+      },
+      selectGroup(group) {
+        store.setCurrentGroup(group)
       }
     }
   }
@@ -88,6 +92,7 @@
   }
   .group-name {
     margin-right: 1rem;
+    cursor: pointer;
   }
   .group-notice {
     height: 1.5rem;

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -1,0 +1,8 @@
+export default {
+  state: {
+    currentGroup: {}
+  },
+  setCurrentGroup(group) {
+    this.state.currentGroup = group
+  }
+}


### PR DESCRIPTION
# 変更内容の説明
- store.jsを作成し、これまでChatMainコンポーネントで行っていたcurrentGroupの状態管理を共通化しました
  - Sidebarコンポーネントからの操作で状態を変更する必要が出たためです
- ChatMainコンポーネントのActionCableから配信があった際の処理に、updateやdestroyされたものがcurrentGroupであるかどうかの検証を実装しました

# ユーザーストーリー
- サイドバーからグループ名を選択すると、ヘッダのグループ名が選んだものに変化するようになりました

# プルリク提出時の確認事項
下記全てにチェック（x）をつけてから提出しましょう。

## コーディングの品質向上

- [x] **1.コメント**：初心者エンジニアにも分かりやすいような、相手目線でのコメントを書いた。
- [x] **2.テスト**：ユースケースが追加/変更された場合は、それに対して変更に強いテストを書いた。

## プルリクの品質向上
- [x] **3.UIのキャプチャ**：UIに変更がある場合は、変更点が分かりやすく伝わるように、キャプチャを貼っている。
![group_select](https://user-images.githubusercontent.com/43090220/86564205-c6d8f000-bfa0-11ea-8320-9f60e85dc78a.gif)
