### PR TITLE
[開発研修]Add api messages index

### DIFF
--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,6 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    render json: group.messages
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,7 @@
 class Group < ApplicationRecord
+  # associations
+  has_many :messages, dependent: :destroy
+
   # validations
   validates :name, presence: true
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,7 @@
+class Message < ApplicationRecord
+  # associations
+  belongs_to :group
+
+  # validations
+  validates :content, presence: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   root 'home#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
-    resources :groups, only: [:index, :create, :show, :update, :destroy]
+    resources :groups, only: [:index, :create, :show, :update, :destroy] do
+      resources :messages, only: :index
+    end
   end
 end

--- a/database.md
+++ b/database.md
@@ -46,10 +46,8 @@
 |name|type|options|
 |-|-|-|
 |content|text|null: false|
-|user|references|null: false, foreign_key: true|
 |group|references|null: false, foreign_key: true|
 ## associations
-- belongs_to :user
 - belongs_to :group
 ## validations
 - validates :content, presence: true

--- a/db/migrate/20200706044615_create_messages.rb
+++ b/db/migrate/20200706044615_create_messages.rb
@@ -1,0 +1,9 @@
+class CreateMessages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :messages do |t|
+      t.text :content, null: false
+      t.references :group, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_02_102511) do
+ActiveRecord::Schema.define(version: 2020_07_06_044615) do
 
   create_table "groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_messages_on_group_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -25,4 +33,5 @@ ActiveRecord::Schema.define(version: 2020_07_02_102511) do
     t.index ["name"], name: "index_users_on_name"
   end
 
+  add_foreign_key "messages", "groups"
 end

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,6 +8,7 @@
 <script>
   import Sidebar from './components/Sidebar.vue'
   import ChatMain from './components/ChatMain.vue'
+  import {getMessages} from './modules/api'
 
   export default {
     data: ()=>{
@@ -18,6 +19,18 @@
       Sidebar,
       ChatMain
     },
+    methods: {
+      fetchMessages(group) {
+        getMessages(group)
+          .then((res)=>{
+            if (res.status === 200) {
+              this.$store.setMessageList(res.data)
+            } else {
+              alert(`${res.status} ${res.statusText}`)
+            }
+          })
+      },
+    }
   }
 </script>
 

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -23,7 +23,7 @@
 
 <script>
   import axios from 'axios'
-  import {deleteGroup} from '../modules/api'
+  import {getGroup, deleteGroup} from '../modules/api'
   import Modal from './Modal.vue'
 
   export default {
@@ -43,7 +43,7 @@
           // data.actionにどのアクションから来たか(create/update/destroy)を格納してある
           if (data.action === 'update' && data.group.id === this.sharedState.currentGroup.id) {
             // updateかつ、currentGroupへの更新ならヘッダのグループ名を更新
-            store.setCurrentGroup(data.group)
+            this.$store.setCurrentGroup(data.group)
           } else if (data.action === 'destroy' && data.removed_id === this.sharedState.currentGroup.id) {
             // destroyかつ、currentGroupが削除されたなら別のグループが送られてきているので削除されたことを通知して移動
             alert('このグループは削除されたため、別のグループへ移動します')
@@ -65,15 +65,14 @@
         this.modalEdit = false
       },
       fetchCurrentGroup(id) {
-        axios
-          .get(`/api/groups/${id}`)
-            .then((res) => {
-              // currentGroupの状態はstoreで管理している
-              // store内のデータ書き換えはstore内のメソッドに任せる
-              this.$store.setCurrentGroup(res.data)
-              // メッセージ一覧もセットで取得する
-              this.$parent.fetchMessages(res.data)
-            })
+        getGroup(id)
+          .then((res) => {
+            // currentGroupの状態はstoreで管理している
+            // store内のデータ書き換えはstore内のメソッドに任せる
+            this.$store.setCurrentGroup(res.data)
+            // メッセージ一覧もセットで取得する
+            this.$parent.fetchMessages(res.data)
+          })
       },
       updateGroup() {
         this.$refs.modalEdit.updateGroup(this.sharedState.currentGroup.id)

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -12,24 +12,7 @@
       <p @click="destroyGroup" class='remove-group-btn'>チャットグループを削除する</p>
     </header>
     <section class='message-container'>
-      <p class='message'>hello</p>
-      <p class='message'>hi</p>
-      <p class='message'>good bye</p>
-      <p class='message'>hello</p>
-      <p class='message'>hi</p>
-      <p class='message'>good bye</p>
-      <p class='message'>hello</p>
-      <p class='message'>hi</p>
-      <p class='message'>good bye</p>
-      <p class='message'>hello</p>
-      <p class='message'>hi</p>
-      <p class='message'>good bye</p>
-      <p class='message'>hello</p>
-      <p class='message'>hi</p>
-      <p class='message'>good bye</p>
-      <p class='message'>hello</p>
-      <p class='message'>hi</p>
-      <p class='message'>good bye</p>
+      <p v-for="message in sharedState.messageList" :key="message.id" class='message'>{{ message.content }}</p>
     </section>
     <form action="#" class="message-form">
       <input type="text" class='message-text-field'>
@@ -40,7 +23,6 @@
 
 <script>
   import axios from 'axios'
-  import store from '../store'
   import {deleteGroup} from '../modules/api'
   import Modal from './Modal.vue'
 
@@ -48,10 +30,10 @@
     components: { Modal },
     data() {
       return {
-        modalEdit: false,
-        sharedState: store.state, // store.stateまでしか読めない？currentGroupつけるとエラー
         groupChannel: null, // ActionCable用
-        token: ''
+        modalEdit: false,
+        sharedState: this.$store.state, // store.stateまでしか読めない？currentGroupつけるとエラー
+        token: '',
       }
     },
     created() {
@@ -61,11 +43,11 @@
           // data.actionにどのアクションから来たか(create/update/destroy)を格納してある
           if (data.action === 'update') {
             // updateならdataはcurrentGroupと同じグループのはずなのでヘッダのグループ名を更新
-            store.setCurrentGroup(data.group)
+            this.$store.setCurrentGroup(data.group)
           } else if (data.action === 'destroy') {
             // destroyなら別のグループが送られてきているので削除されたことを通知して移動
             alert('このグループは削除されたため、別のグループへ移動します')
-            store.setCurrentGroup(data.group)
+            this.$store.setCurrentGroup(data.group)
           }
           // createの時は何もしない(Sidebarコンポーネントの更新はある)
         },
@@ -88,7 +70,9 @@
             .then((res) => {
               // currentGroupの状態はstoreで管理している
               // store内のデータ書き換えはstore内のメソッドに任せる
-              store.setCurrentGroup(res.data)
+              this.$store.setCurrentGroup(res.data)
+              // メッセージ一覧もセットで取得する
+              this.$parent.fetchMessages(res.data)
             })
       },
       updateGroup() {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -17,7 +17,6 @@
 
 <script>
   import axios from 'axios'
-  import store from '../store'
   import {getGroups} from '../modules/api'
   import Modal from './Modal.vue'
 
@@ -27,7 +26,7 @@
       return {
         modalNew: false,
         groupList: [],
-        groupChannel: null // ActionCable用
+        groupChannel: null, // ActionCable用
       }
     },
     created() {
@@ -60,7 +59,8 @@
         this.$refs.modalNew.createGroup()
       },
       selectGroup(group) {
-        store.setCurrentGroup(group)
+        this.$store.setCurrentGroup(group)
+        this.$parent.fetchMessages(group)
       }
     }
   }

--- a/frontend/src/config/constant.js
+++ b/frontend/src/config/constant.js
@@ -1,0 +1,3 @@
+export default {
+  LocalOrigin: 'http://localhost:3000',
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,6 +7,11 @@ import ActionCable from 'actioncable'
 const cable = ActionCable.createConsumer('ws:localhost:3000/cable');
 Vue.prototype.$cable = cable;
 
+// storeのグローバル化
+// 全コンポーネントからthis.$storeで呼べる
+import store from './store'
+Vue.prototype.$store = store
+
 // App.vueをエントリとしてレンダリング
 new Vue({
   el: '#app',

--- a/frontend/src/modules/api.js
+++ b/frontend/src/modules/api.js
@@ -74,3 +74,8 @@ export const deleteGroup = (token, groupId, groupChannel)=> {
         }
       })
 }
+
+// メッセージ全件取得
+export const getMessages = (group)=> {
+  return axios.get(`/api/groups/${group.id}/messages`)
+}

--- a/frontend/src/modules/api.js
+++ b/frontend/src/modules/api.js
@@ -1,10 +1,12 @@
 import axios from 'axios'
+import constant from '../config/constant'
 
 // グループ全件取得
 // /api/groupsを叩き、結果をgroupListに入れる
 export const getGroups = (groupList)=> {
+  const path = '/api/groups'
   axios
-    .get('/api/groups')
+    .get(constant.LocalOrigin + path)
       .then(
         (res) => {
           for(var i = 0; i < res.data.length; i++) {
@@ -18,10 +20,17 @@ export const getGroups = (groupList)=> {
       )
 }
 
+// グループ1件取得
+export const getGroup = (id)=>{
+  const path = `/api/groups/${id}`
+  return axios.get(constant.LocalOrigin + path)
+}
+
 // グループ作成
 export const postGroup = (token, groupName, groupChannel)=> {
+  const path = '/api/groups'
   axios
-    .post('/api/groups', {
+    .post(constant.LocalOrigin + path, {
       authenticity_token: token,
       name: groupName
     })
@@ -38,8 +47,9 @@ export const postGroup = (token, groupName, groupChannel)=> {
 
 // グループ編集
 export const putGroup = (token, groupId, groupName, groupChannel)=> {
+  const path = `/api/groups/${groupId}`
   axios
-    .put(`/api/groups/${groupId}`, {
+    .put(constant.LocalOrigin + path, {
       authenticity_token: token,
       name: groupName
     })
@@ -56,8 +66,9 @@ export const putGroup = (token, groupId, groupName, groupChannel)=> {
 
 // グループ削除
 export const deleteGroup = (token, groupId, groupChannel)=> {
+  const path = `/api/groups/${groupId}`
   axios
-    .delete(`/api/groups/${groupId}`, {
+    .delete(constant.LocalOrigin + path, {
       data: { // deleteでparamsを送りたい時は data: が必要
         authenticity_token: token
       }
@@ -76,5 +87,6 @@ export const deleteGroup = (token, groupId, groupChannel)=> {
 
 // メッセージ全件取得
 export const getMessages = (group)=> {
-  return axios.get(`/api/groups/${group.id}/messages`)
+  const path = `/api/groups/${group.id}/messages`
+  return axios.get(constant.LocalOrigin + path)
 }

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -1,8 +1,12 @@
 export default {
   state: {
-    currentGroup: {}
+    currentGroup: {},
+    messageList: [],
   },
   setCurrentGroup(group) {
     this.state.currentGroup = group
+  },
+  setMessageList(messageList) {
+    this.state.messageList = messageList
   }
 }

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :message do
+    content { Faker::Lorem.sentence }
+    group
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Message, type: :model do
+  describe 'validation' do
+    context 'valid' do
+      it 'ファクトリを使って正常に保存できる' do
+        message = build(:message)
+        expect(message).to be_valid
+      end
+    end
+
+    context 'invalid' do
+      it 'contentが空では保存できない' do
+        message = build(:message, content: '')
+        expect(message).to be_invalid
+      end
+    end
+  end
+end

--- a/spec/requests/api/messages_request_spec.rb
+++ b/spec/requests/api/messages_request_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Messages", type: :request do
+
+  describe "#index (GET /api/groups/:group_id/messages)" do
+    let(:group) { create(:group) }
+
+    it "正常なレスポンスを返す" do
+      create_list(:message, 10)
+      create_list(:message, 5, group: group)
+
+      get api_group_messages_path(group)
+      json = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:success)
+      expect(json.length).to eq 5
+    end
+  end
+
+end


### PR DESCRIPTION
# 変更内容の説明
- Messageモデルを作成しました
- api/messages#indexを実装し、送られてきたidのグループで投稿されたmessage一覧を返すようにしました
- api.jsにgetMessagesを実装し、上記messages#indexを叩くようにしました
- AppコンポーネントにfetchMessagesメソッドを実装し、group1件を受け取って上記getMessagesを呼ぶようにしました
  - Sidebarコンポーネントでグループの選択時、選択されたグループを渡して上記fetchMessagesを呼ぶようにしました
  - ChatMainコンポーネントのマウント時、最もidが若いグループを渡して上記fetchMessagesを呼ぶようにしました
- store.jsを各コンポーネントで個別にimportするのではなく、main.jsでグローバル変数$storeに格納しました

# ユーザーストーリー
- ルートパスにアクセス時、一番上のグループのメッセージ一覧が表示されるようになりました
- サイドバーからグループの選択時、そのグループで投稿されたメッセージ一覧が表示されるようになりました

# プルリク提出時の確認事項
下記全てにチェック（x）をつけてから提出しましょう。

## コーディングの品質向上

- [x] **1.コメント**：初心者エンジニアにも分かりやすいような、相手目線でのコメントを書いた。
- [x] **2.テスト**：ユースケースが追加/変更された場合は、それに対して変更に強いテストを書いた。

## プルリクの品質向上
- [x] **3.UIのキャプチャ**：UIに変更がある場合は、変更点が分かりやすく伝わるように、キャプチャを貼っている。
![messages_index](https://user-images.githubusercontent.com/43090220/86687640-597c9c00-c040-11ea-96e4-65159b2e7a79.gif)
