### PR TITLE
[開発研修]Add messages create

### DIFF
--- a/app/channels/group_channel.rb
+++ b/app/channels/group_channel.rb
@@ -10,4 +10,9 @@ class GroupChannel < ApplicationCable::Channel
   def display(data)
     ActionCable.server.broadcast 'group_channel', data['group']
   end
+
+  def talk(data)
+    ActionCable.server.broadcast 'group_channel', message: data['message']
+  end
+
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -3,4 +3,16 @@ class Api::MessagesController < ApplicationController
     group = Group.find(params[:group_id])
     render json: group.messages
   end
+
+  def create
+    group = Group.find(params[:group_id])
+    message = group.messages.create(message_params)
+    render json: message
+  end
+
+  private
+
+  def message_params
+    params.permit(:content)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
     resources :groups, only: [:index, :create, :show, :update, :destroy] do
-      resources :messages, only: :index
+      resources :messages, only: [:index, :create]
     end
   end
 end

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -14,8 +14,8 @@
     <section class='message-container'>
       <p v-for="message in sharedState.messageList" :key="message.id" class='message'>{{ message.content }}</p>
     </section>
-    <form action="#" class="message-form">
-      <input type="text" class='message-text-field'>
+    <form @submit.prevent="createMessage" action="#" class="message-form">
+      <input v-model="messageContent" type="text" class='message-text-field'>
       <input type="submit" class='submit-btn'>
     </form>
   </article>
@@ -23,7 +23,7 @@
 
 <script>
   import axios from 'axios'
-  import {deleteGroup} from '../modules/api'
+  import {deleteGroup, postMessage} from '../modules/api'
   import Modal from './Modal.vue'
 
   export default {
@@ -31,6 +31,7 @@
     data() {
       return {
         groupChannel: null, // ActionCable用
+        messageContent: '',
         modalEdit: false,
         sharedState: this.$store.state, // store.stateまでしか読めない？currentGroupつけるとエラー
         token: '',
@@ -64,6 +65,7 @@
       closeEditModal() {
         this.modalEdit = false
       },
+      // グループ CRUD操作
       fetchCurrentGroup(id) {
         axios
           .get(`/api/groups/${id}`)
@@ -82,6 +84,18 @@
         if (confirm('本当に削除しますか？')) {
           deleteGroup(this.token, this.sharedState.currentGroup.id, this.groupChannel)
         }
+      },
+      // グループ関係ここまで
+      createMessage() {
+        postMessage(this.sharedState.currentGroup, this.messageContent, this.token)
+          .then((res)=>{
+            if (res.status === 200) {
+              console.log(res.data)
+              this.messageContent = ''
+            } else {
+              alert(`${res.status} ${res.statusText}`)
+            }
+          })
       }
     }
   }

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -57,7 +57,7 @@
           } else if (data.action === 'destroy' && data.removed_id === this.sharedState.currentGroup.id) {
             // destroyかつ、currentGroupが削除されたなら別のグループが送られてきているので削除されたことを通知して移動
             alert('このグループは削除されたため、別のグループへ移動します')
-            this.$store.setCurrentGroup(data.group)
+            this.fetchCurrentGroup(data.group.id)
           }
           // createの時は何もしない(Sidebarコンポーネントの更新はある)
         },

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,6 +7,11 @@ import ActionCable from 'actioncable'
 const cable = ActionCable.createConsumer('ws:localhost:3000/cable');
 Vue.prototype.$cable = cable;
 
+// storeのグローバル化
+// 全コンポーネントからthis.$storeで呼べる
+import store from './store'
+Vue.prototype.$store = store
+
 // App.vueをエントリとしてレンダリング
 new Vue({
   el: '#app',

--- a/frontend/src/modules/api.js
+++ b/frontend/src/modules/api.js
@@ -56,7 +56,6 @@ export const putGroup = (token, groupId, groupName, groupChannel)=> {
 
 // グループ削除
 export const deleteGroup = (token, groupId, groupChannel)=> {
-  console.log(token)
   axios
     .delete(`/api/groups/${groupId}`, {
       data: { // deleteでparamsを送りたい時は data: が必要

--- a/frontend/src/modules/api.js
+++ b/frontend/src/modules/api.js
@@ -79,3 +79,12 @@ export const deleteGroup = (token, groupId, groupChannel)=> {
 export const getMessages = (group)=> {
   return axios.get(`/api/groups/${group.id}/messages`)
 }
+
+// メッセージ作成
+export const postMessage = (group, content, token)=> {
+  return axios
+    .post(`/api/groups/${group.id}/messages`, {
+      authenticity_token: token,
+      content: content,
+    })
+}

--- a/spec/requests/api/messages_request_spec.rb
+++ b/spec/requests/api/messages_request_spec.rb
@@ -17,4 +17,34 @@ RSpec.describe "Api::Messages", type: :request do
     end
   end
 
+  describe "#create (POST /api/groups/:group_id/messages)", focus: true do
+    let(:group) { create(:group) }
+
+    context 'valid params' do
+      let(:valid_params) {{ content: 'some messages' }}
+
+      it "メッセージが1件増え、正常なレスポンスを返す" do
+        expect {
+          post api_group_messages_path(group), params: valid_params
+        }.to change(Message, :count).by(1)
+
+        json = JSON.parse(response.body)
+
+        expect(response).to have_http_status(:success)
+        expect(json['content']).to eq 'some messages'
+        expect(json['group_id']).to eq group.id
+      end
+    end
+
+    context 'invalid params' do
+      let(:invalid_params) {{ content: '' }}
+
+      it 'メッセージが増えない' do
+        expect {
+          post api_group_messages_path(group), params: invalid_params
+        }.to_not change(Message, :count)
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
# 変更内容の説明
- api/messages#createを実装し、messagesのレコードを作成できるようにしました
- api.jsにpostMessageを実装し、group1件と文字列を受け取って上記messages#createを叩くようにしました
- ChatMainコンポーネントにcreateMessageを実装し、currentGroupとメッセージ入力内容を渡して上記postMessageを呼ぶようにしました
  - group_channel#talk を実装し、受け取ったデータをmessageというキーに格納して配信するようにしました
  - postMessageからのレスポンス受信時、上記group_channel#talkを叩き作成したmessageを渡すようにしました
  - ChatMainコンポーネントのActionCableからの配信時の処理に、message1件を受け取ったらstore.messageListに追加する処理を実装しました

# ユーザーストーリー
- ヘッダに表示されているグループに対してメッセージを送信できるようになりました
- ヘッダに表示されているグループに他のユーザーからのメッセージが送信されると、非同期的にメッセージが追加されるようになりました

# プルリク提出時の確認事項
下記全てにチェック（x）をつけてから提出しましょう。

## コーディングの品質向上

- [x] **1.コメント**：初心者エンジニアにも分かりやすいような、相手目線でのコメントを書いた。
- [x] **2.テスト**：ユースケースが追加/変更された場合は、それに対して変更に強いテストを書いた。

## プルリクの品質向上
- [x] **3.UIのキャプチャ**：UIに変更がある場合は、変更点が分かりやすく伝わるように、キャプチャを貼っている。
![messages_create](https://user-images.githubusercontent.com/43090220/86712440-fac31c80-c057-11ea-87ae-8243329f4263.gif)
